### PR TITLE
changed sys to util

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,4 +1,4 @@
-var sys = require('sys');
+var sys = require('util');
 var events = require('events');
 var fs = require('fs');
 var exec = require('child_process').exec;


### PR DESCRIPTION
changed `require('sys')` to `require('util')` I left the sys variable as... it is for compatibility reasons with the code.
