### PR TITLE
support for Sprockets using Snockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Via [npm](http://github.com/isaacs/npm):
                 'jquery.js'
                 , 'jquery.client.js'
             ]
+            , 'preManipulate': {
+                '^': [
+                    assetHandler.snockets
+                ]
+            }
             , 'postManipulate': {
                 '^': [
                     assetHandler.uglifyJsOptimize
@@ -45,6 +50,8 @@ Via [npm](http://github.com/isaacs/npm):
 ## Handlers
 ### uglifyJsOptimize
 Uses UglifyJS to compress the give javascript files.
+### snockets
+Uses Sprockets/Snockets-style comments to indicate javascript dependencies using //= require dependency and //= require_tree dir
 ### yuiJsOptimize
 Uses YUI Compressor to compress the given javascript files.
 ### yuiCssOptimize

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -62,11 +62,11 @@ function handlers()
 		callback(uglifyProcess.gen_code(ast));
 	};
 	this.snockets = function(file, path, index, isLast, callback) {
-		return snockets.getConcatenation(path, function(err, js) {
+		snockets.getConcatenation(path, function(err, js) {
 			if (js) {
-				return callback(js);
+				callback(js);
 			} else {
-				return callback(err);
+				callback(err);
 			}
 		});
 	};

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -7,6 +7,8 @@ var step = require('step');
 var uglifyParser = require('uglify-js').parser;
 var uglifyProcess = require('uglify-js').uglify;
 var YahooCssMin = require("../deps/cssmin");
+var Snockets = require('snockets');
+var snockets = new Snockets();
 module.exports = new handlers();
 
 
@@ -58,6 +60,15 @@ function handlers()
 		ast = uglifyProcess.ast_mangle(ast);
 		ast = uglifyProcess.ast_squeeze(ast);
 		callback(uglifyProcess.gen_code(ast));
+	};
+	this.snockets = function(file, path, index, isLast, callback) {
+		return snockets.getConcatenation(path, function(err, js) {
+			if (js) {
+				return callback(js);
+			} else {
+				return callback(err);
+			}
+		});
 	};
 	this.fixGradients = function (file, path, index, isLast, callback) {
 		callback(file.replace(/gradient: *([^_]+)_([^;]+);/g, function(str, c1, c2) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "repository" : { "type":"git", "url":"http://github.com/mape/connect-assetmanager-handlers.git" },
   "dependencies" : {
     "request" : ">=0.9.5",
+    "snockets": ">=1.3.7",
     "step" : ">=0.0.3",
     "uglify-js" : ">=0.0.1"
   }


### PR DESCRIPTION
rather then using the javascript settings. Snockets allows us to use javascript comments to include dependency

``` javascript
//= require console.log
//= require _libs/json2
//= require _libs/jquery-1.7.2
//= require _libs/underscore
//= require _libs/backbone
//= require app
//= require_tree models/
//= require_tree collections/
//= require_tree routers/
```

Takes dependency on snockets. https://github.com/TrevorBurnham/snockets
