### PR TITLE
Add replaceCSSImageURLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,13 @@ Simply replaces `data-url` with `url`. Used as a complement with replaceImageRef
 
 ### fixFloatDoubleMargin
 Finds all blocks containing floats and add a display: inline; (unless there is another display set in that block) to fix double margin bugs. 
+
+### replaceCSSImageURLs
+Finds all relative CSS image URLs, and replaces them to be absolute. THis ensures that there are no broken image references, even if loading images to the asset manager from different directories.
+
+Arguments:
+
+ * **Root** - The root directory of your server. Not the public folder, but your server.
+ 
+#### Setup
+    assetHandler.replaceCSSImageURLs(root)

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -188,4 +188,51 @@ function handlers()
 			}
 		}));
 	};
+	this.replaceCSSImageURLs = function(root) {
+
+		return function(file, path, index, isLast, callback) {
+
+			var relativePath = path.replace(root, '');
+
+			var segments = relativePath.split('/');
+			delete segments[segments.length - 1];
+
+			relativePath = segments.join('/');
+
+			var regex = /url\([^\)]*\)/;
+			var matches = [];
+			var tmpFile = file;
+			while (regex.test(tmpFile) !== false) {
+				var match = regex.exec(tmpFile)[0];
+				matches.push(match);
+				tmpFile = tmpFile.replace(match, '');
+			}
+
+			for (var i = 0; i < matches.length; i++) {
+				var result = matches[i];
+				var s = result;
+				var hasQuotes = (s.indexOf('url("') !== -1 || s.indexOf("url('") !== -1);
+				if (hasQuotes)
+					s = s.substring(5, s.length - 2);
+				else
+					s = s.substring(4, s.length - 1);
+
+				var external = false;
+				if (s.indexOf("http://") === 0) external = true;
+				if (s.indexOf("https://") === 0) external = true;
+				if (s.indexOf("/") === 0) external = true;
+
+				if (external === true)
+					continue;
+
+				var newURL = relativePath + s;
+
+				file = file.replace(result, "url('" + newURL + "')");
+			}
+
+			callback(file);
+
+		}
+
+	};
 }


### PR DESCRIPTION
I needed a helper function to relative background image URLs in CSS files with the correct absolute path, so I made this helper.

It takes one argument, the root of the site, and uses it to form the new absolute URLs to the correct image content.

I've tested it with some pretty complicated stylesheets, and it worked flawlessly.
