### PR TITLE
Fix uglify version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "dependencies" : {
     "request" : ">=0.9.5",
     "step" : ">=0.0.3",
-    "uglify-js" : ">=0.0.1"
+    "uglify-js" : "1.X.X"
   }
 }


### PR DESCRIPTION
Restrict the version to a known working version.

UglifyJS2 is not backwards compatible, so we mustn't use that version.
